### PR TITLE
Remove default_executable, it is deprecated in latest Rubygems with no re

### DIFF
--- a/sprite.gemspec
+++ b/sprite.gemspec
@@ -2,7 +2,6 @@ Gem::Specification.new do |s|
   s.name = "sprite"
   s.version = "0.2.2"
 
-  s.default_executable = "sprite"
   s.executables = ["sprite"]
 
   s.authors = ["Jacques Crocker", "Alf Mikula"]


### PR DESCRIPTION
Remove default_executable, it is deprecated in latest Rubygems with no replacement.
