### PR TITLE
Fixed Marshal.dump call causing 'illegal hardware exception' on OS X ruby

### DIFF
--- a/lib/sprite/styles/sass_mixin_generator.rb
+++ b/lib/sprite/styles/sass_mixin_generator.rb
@@ -9,14 +9,12 @@ module Sprite
       def write(path, sprite_files)
         # write the sass mixins to disk
         File.open(File.join(Sprite.root, path), 'w') do |f|
-          add_else = false
 
           f.puts "= sprite($group_name, $image_name, $offset: 0)"
           sprite_files.each do |sprite_file, sprites|
             background_url = @builder.background_url(sprite_file)
             sprites.each do |sprite|
               f << "  @"
-              add_else = true
               #{sprite[:x]}px #{sprite[:y]}px
 
               if sprite[:align] == 'horizontal'


### PR DESCRIPTION
With sass 3.1.7, in lib/sass/tree/if_node.rb:39, it calls:
Marshal.dump([self.expr, self.else, self.children])
The problem is that for sprites with lots of files, the Marshal.dump call on self.else causes an 'illegal hardware exception' on OS X with ruby 1.9.2. To fix it, we changed the "if...else if..." pattern generated by the sass mixin generator to a straight "if...if.." pattern. It's a little less efficient, but this only gets parsed on the initial request to a site. This doesn't seem to be an issue in ruby 1.9.3 (it seems Marshal.dump on OS X was fixed). It also doesn't seem to be an issue on Ubuntu with ruby 1.9.2.
