### PR TITLE
MaxRGB is a deprecated constant

### DIFF
--- a/lib/sprite/image_combiner.rb
+++ b/lib/sprite/image_combiner.rb
@@ -18,7 +18,7 @@ module Sprite
       if @image_config.background_color
         image.opacity = 0
       else
-        image.opacity = Magick::MaxRGB
+        image.opacity = Magick::QuantumRange
       end
 
       image.composite!(dest_image, 0, 0, Magick::OverCompositeOp)


### PR DESCRIPTION
/Users/zoomsamara/.rvm/gems/ruby-2.2.1/gems/sprite-0.2.7/lib/sprite/image_combiner.rb:21:in `composite_images': uninitialized constant Magick::MaxRGB (NameError)
